### PR TITLE
chore: added editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,19 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+indent_size = 4
+indent_style = tab
+max_line_length = 100
+
+[**.{yaml,yml}]
+indent_size = 2
+indent_style = space
+
+[**.md]
+indent_size = 2
+indent_style = space
+max_line_length = 120

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -2,6 +2,7 @@
 	// See http://go.microsoft.com/fwlink/?LinkId=827846
 	// for the documentation about the extensions.json format
 	"recommendations": [
-		"dbaeumer.vscode-eslint"
+		"dbaeumer.vscode-eslint",
+		"EditorConfig.EditorConfig"
 	]
 }


### PR DESCRIPTION
Editorconfig is a common tool used for enforcing editors configuration,
it allows for collaborating between multiple contributors with different editor configuration:
https://editorconfig.org/

A linter for all file types based on editorconfig:
https://github.com/editorconfig-checker/editorconfig-checker

A vscode extension for applying editorconfig:
https://marketplace.visualstudio.com/items?itemName=EditorConfig.EditorConfig

A vim plugin for applying editorconfig:
https://github.com/editorconfig/editorconfig-vim

